### PR TITLE
Use trusty dist in travis ci to support 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 cache: bundler
 rvm:
   - 2.4.1


### PR DESCRIPTION
https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta