### PR TITLE
Runs db:test:prepare on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 cache: bundler
 rvm:
   - 2.4.1
-before_script: bin/setup
+before_script: bin/rake db:test:prepare
 script: bin/rspec
 bundler_args: --without production
 addons:


### PR DESCRIPTION
At this time, we want to avoid seeds getting into the test database because our tests do not (yet?) expect this.