### PR TITLE
Fix observation session query

### DIFF
--- a/app/controllers/api/observation_sessions_controller.rb
+++ b/app/controllers/api/observation_sessions_controller.rb
@@ -1,24 +1,22 @@
+# frozen_string_literal: true
+
 module Api
   class ObservationSessionsController < BaseController
     def create
       ActiveRecord::Base.transaction do
-        
-      session_ids_to_instances = {} 
-      processed_observations = []   
+        session_ids_to_instances = {}
 
-      observations_params.each do | observation |
-          session = session_ids_to_instances.fetch(observation['observation_session_id']) do | session_id |
+        processed_observations = observations_params.map do |observation|
+          session = session_ids_to_instances.fetch(observation['observation_session_id']) do |session_id|
             session_ids_to_instances[session_id] = ObservationSession.find_or_create_by(id: session_id, user_id: current_user.id)
           end
-          
+
           Observation.find_or_create_by(id: observation['id']) do |record|
             record.details = observation
             record.observation_session = session
-            record.save
-            processed_observations << record
           end
         end
-        
+
         response = processed_observations.map { |o| { id: o.id, persisted: o.persisted?, errors: o.errors.full_messages } }
         render json: response, status: :ok
       end

--- a/app/controllers/api/observation_sessions_controller.rb
+++ b/app/controllers/api/observation_sessions_controller.rb
@@ -2,36 +2,24 @@ module Api
   class ObservationSessionsController < BaseController
     def create
       ActiveRecord::Base.transaction do
-        create_observation_sessions
-        # TODO: upsert?
-        puts observations_params.inspect
-        # observations = observations_params.map do |observation|
-        #   observation_session = ObservationSession.find_by(id: observation['observation_session_id'])
-        #   Observation.find_or_create_by(id: observation['id']) do |record|
-        #     record.details = observation
-        #     record.observation_session = observation_session
-        #     record.save
-        #   end
-        # end
-
-        observations = []
-        session_ids_to_instances =  observations_params
-          .map {|param| param['observation_session_id']}
-          .uniq
-          .map { |session_id| ObservationSession.find_or_create_by(id: session_id) }
-          .group_by { |session| session.id }
         
- 
-        observations_params.each do | observation |
+      session_ids_to_instances = {} 
+      processed_observations = []   
+
+      observations_params.each do | observation |
+          session = session_ids_to_instances.fetch(observation['observation_session_id']) do | session_id |
+            session_ids_to_instances[session_id] = ObservationSession.find_or_create_by(id: session_id, user_id: current_user.id)
+          end
+          
           Observation.find_or_create_by(id: observation['id']) do |record|
             record.details = observation
-            record.observation_session = session_ids_to_instances[observation['observation_session_id']][0]
+            record.observation_session = session
             record.save
-            observations << record
+            processed_observations << record
           end
         end
         
-        response = observations.map { |o| { id: o.id, persisted: o.persisted?, errors: o.errors.full_messages } }
+        response = processed_observations.map { |o| { id: o.id, persisted: o.persisted?, errors: o.errors.full_messages } }
         render json: response, status: :ok
       end
     rescue ActiveRecord::StatementInvalid => e
@@ -39,29 +27,6 @@ module Api
     end
 
     private
-
-    # def create_observation_sessions
-    #   observations_params
-    #     .map { |o| o['observation_session_id'] }
-    #     .uniq
-    #     .map { |id| { id: id, user_id: current_user.id } }
-    #     .map do |attrs|
-    #     ObservationSession.create_once(attrs)
-    #   end
-    # end
-
-    def create_observation_sessions
-      unique_sessions = observations_params
-        .map { |o| o['observation_session_id'] }
-        .uniq
-
-      selector_map = unique_sessions
-        .map { |id| { id: id, user_id: current_user.id } }
-      
-      selector_map.each do |selector|
-        ObservationSession.create_once(selector)
-      end
-    end
 
     def observations_params
       params.fetch('observations', [])

--- a/app/controllers/api/observation_sessions_controller.rb
+++ b/app/controllers/api/observation_sessions_controller.rb
@@ -4,13 +4,33 @@ module Api
       ActiveRecord::Base.transaction do
         create_observation_sessions
         # TODO: upsert?
-        observations = observations_params.map do |observation|
+        puts observations_params.inspect
+        # observations = observations_params.map do |observation|
+        #   observation_session = ObservationSession.find_by(id: observation['observation_session_id'])
+        #   Observation.find_or_create_by(id: observation['id']) do |record|
+        #     record.details = observation
+        #     record.observation_session = observation_session
+        #     record.save
+        #   end
+        # end
+
+        observations = []
+        session_ids_to_instances =  observations_params
+          .map {|param| param['observation_session_id']}
+          .uniq
+          .map { |session_id| ObservationSession.find_or_create_by(id: session_id) }
+          .group_by { |session| session.id }
+        
+ 
+        observations_params.each do | observation |
           Observation.find_or_create_by(id: observation['id']) do |record|
             record.details = observation
-            record.observation_session_id = observation['observation_session_id']
+            record.observation_session = session_ids_to_instances[observation['observation_session_id']][0]
+            record.save
+            observations << record
           end
         end
-
+        
         response = observations.map { |o| { id: o.id, persisted: o.persisted?, errors: o.errors.full_messages } }
         render json: response, status: :ok
       end
@@ -20,13 +40,26 @@ module Api
 
     private
 
+    # def create_observation_sessions
+    #   observations_params
+    #     .map { |o| o['observation_session_id'] }
+    #     .uniq
+    #     .map { |id| { id: id, user_id: current_user.id } }
+    #     .map do |attrs|
+    #     ObservationSession.create_once(attrs)
+    #   end
+    # end
+
     def create_observation_sessions
-      observations_params
+      unique_sessions = observations_params
         .map { |o| o['observation_session_id'] }
         .uniq
+
+      selector_map = unique_sessions
         .map { |id| { id: id, user_id: current_user.id } }
-        .map do |attrs|
-        ObservationSession.create_once(attrs)
+      
+      selector_map.each do |selector|
+        ObservationSession.create_once(selector)
       end
     end
 

--- a/spec/controllers/api/observation_sessions_controller_spec.rb
+++ b/spec/controllers/api/observation_sessions_controller_spec.rb
@@ -25,8 +25,40 @@ RSpec.describe Api::ObservationSessionsController, type: :controller do
               "subject": "Minerva",
               "behavior": "fighting",
               "target": "Lulu"
+            },
+            {
+              "id": SecureRandom.uuid,
+              "observation_session_id": uuid,
+              "timestamp": "2017-05-19T01:15:09.728Z",
+              "subject": "Minerva",
+              "behavior": "walking",
+              "modifier": "quickly"
+            },
+            {
+              "id": SecureRandom.uuid,
+              "observation_session_id": uuid,
+              "timestamp": "2017-05-19T01:15:09.728Z",
+              "subject": "Minerva",
+              "behavior": "fighting",
+              "target": "Lulu"
+            },
+            {
+              "id": SecureRandom.uuid,
+              "observation_session_id": uuid,
+              "timestamp": "2017-05-19T01:15:09.728Z",
+              "subject": "Minerva",
+              "behavior": "walking",
+              "modifier": "quickly"
+            },
+            {
+              "id": SecureRandom.uuid,
+              "observation_session_id": uuid,
+              "timestamp": "2017-05-19T01:15:09.728Z",
+              "subject": "Minerva",
+              "behavior": "fighting",
+              "target": "Lulu"
             }
-          ]
+          ] 
         }
         post :create, params: json_params, as: :json
         expect(response).to have_http_status(:success)


### PR DESCRIPTION
This fix caches the `ObservationSession` instance where possible to prevent running a select query against observation sessions every time an observation is inserted. 

It also adds some more JSON observation objects to the test data so that redundant query work will be easier to see in test logs, if it ever comes up again. 